### PR TITLE
feat: additive include filters, external prompts, and XML output format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2.2.0
+
+### Added
+- **XML-structured output format** - Output now uses semantic XML tags for better AI parsing:
+  - `<task>...</task>` - Wraps the prompt/instructions
+  - `<filetree>...</filetree>` - Wraps the project tree structure
+  - `<source_code>...</source_code>` - Wraps all source code files
+- **Additive `--include-dir` and `--include-files`** - These options now work together additively instead of being mutually exclusive. Use both to include specific directories PLUS specific files.
+- **External prompt file support** - Prompt files with paths (e.g., `-p docs/arch/prompt.md`) are now correctly resolved from the project root instead of requiring them to be in `codefetch/prompts/`
+
+### Fixed
+- Fixed `--include-dir` and `--include-files` being mutually exclusive - now they combine additively
+- Fixed external prompt file paths not being found when containing directory separators
+- Fixed prompts without `{{CURRENT_CODEBASE}}` placeholder not including the codebase content
+
 ## 2.1.2
 
 ### Fixed

--- a/HOW-TO-RELEASE.md
+++ b/HOW-TO-RELEASE.md
@@ -160,6 +160,13 @@ Delete the GitHub Release if needed: `gh release delete vX.Y.Z`
 - `npm ERR! code E403` or auth failures: run `npm login` and retry
 - `gh` failures: `gh auth status`; ensure `repo` scope exists
 - Tag push rejected: pull/rebase or fast-forward `main`, then rerun
+- **CI fails with `ERR_PNPM_OUTDATED_LOCKFILE`**: The lockfile is out of sync with `package.json`. This happens when dependencies change (e.g., `workspace:*` → `^2.1.0`). Fix it locally:
+  ```bash
+  pnpm install --no-frozen-lockfile
+  git add pnpm-lock.yaml
+  git commit -m "chore: update pnpm-lock.yaml"
+  git push
+  ```
 
 ## Release Frequency Suggestions
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ npx codefetch --include-files "src/components/AgentPanel.tsx,src/lib/llm/**/*" -
 
 # Include src directory, exclude test files
 npx codefetch --include-dir src --exclude-files "*.test.ts" -o src-no-tests.md
+
+# Combine --include-dir and --include-files (additive!)
+# This includes ALL files from crates/core/src PLUS the specific lib.rs file
+npx codefetch --include-dir crates/core/src --include-files "crates/engine/src/lib.rs" -o combined.md
 ```
 
 Dry run (only output to console)
@@ -289,10 +293,20 @@ Inline prompts are automatically appended with the codebase content.
 
 #### Custom Prompt Files
 
-Create custom prompts in `codefetch/prompts/` directory:
+You can use custom prompt files in two ways:
 
-1. Create a markdown file (e.g., `codefetch/prompts/my-prompt.md`)
-2. Use it with `--prompt my-prompt.md`
+**1. External prompt files (anywhere in your project):**
+```bash
+# Use a prompt file from anywhere in your project
+npx codefetch -p docs/arch/review-prompt.md
+npx codefetch --prompt ./prompts/security-audit.txt
+```
+
+**2. Prompt files in `codefetch/prompts/` directory:**
+```bash
+# Create codefetch/prompts/my-prompt.md, then use:
+npx codefetch --prompt my-prompt.md
+```
 
 You can also set a default prompt in your `codefetch.config.mjs`:
 
@@ -343,6 +357,41 @@ The `.codefetchignore` file works exactly like `.gitignore` and is useful when y
 Codefetch uses a set of default ignore patterns to exclude common files and directories that typically don't need to be included in code reviews or LLM analysis.
 
 You can view the complete list of default patterns in [default-ignore.ts](packages/sdk/src/default-ignore.ts).
+
+## Output Format
+
+Codefetch generates structured output using semantic XML tags to help AI models better understand the different sections:
+
+```xml
+<task>
+Your prompt or instructions here...
+</task>
+
+<filetree>
+Project Structure:
+└── src
+    ├── index.ts
+    └── utils
+        └── helpers.ts
+</filetree>
+
+<source_code>
+src/index.ts
+```typescript
+// Your code here
+```
+
+src/utils/helpers.ts
+```typescript
+// More code here
+```
+</source_code>
+```
+
+The XML structure provides:
+- `<task>` - Contains your prompt/instructions (from `-p` flag)
+- `<filetree>` - Contains the project tree visualization (from `-t` flag)
+- `<source_code>` - Contains all the source code files with their paths
 
 ## Token Counting
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.2.0
+
+### Added
+- **XML-structured output format** - Output now uses semantic XML tags for better AI parsing:
+  - `<task>...</task>` - Wraps the prompt/instructions
+  - `<filetree>...</filetree>` - Wraps the project tree structure
+  - `<source_code>...</source_code>` - Wraps all source code files
+- **External prompt file support** - Prompt files with paths (e.g., `-p docs/arch/prompt.md`) are now correctly resolved from the project root
+
+### Fixed
+- Fixed `getPromptFile` not resolving external file paths correctly when they contain directory separators
+
 ## 2.1.2
 
 ### Fixed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@clack/prompts": "^0.11.0",
     "c12": "^2.0.1",
-    "codefetch-sdk": "^2.1.0",
+    "codefetch-sdk": "workspace:*",
     "consola": "^3.3.3",
     "ignore": "^7.0.0",
     "mri": "^1.2.0",

--- a/packages/cli/src/commands/default.ts
+++ b/packages/cli/src/commands/default.ts
@@ -29,6 +29,15 @@ function getPromptFile(
   if (VALID_PROMPTS.has(config.defaultPromptFile)) {
     return config.defaultPromptFile;
   }
+  // Check if it's an external file path (contains path separator or is absolute)
+  // External paths should be used as-is, not nested under codefetch/prompts/
+  if (
+    config.defaultPromptFile.includes("/") ||
+    config.defaultPromptFile.includes("\\") ||
+    config.defaultPromptFile.startsWith(".")
+  ) {
+    return resolve(config.defaultPromptFile);
+  }
   return resolve(config.outputPath, "prompts", config.defaultPromptFile);
 }
 

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -35,6 +35,15 @@ function getPromptFile(
   if (VALID_PROMPTS.has(config.defaultPromptFile)) {
     return config.defaultPromptFile;
   }
+  // Check if it's an external file path (contains path separator or is absolute)
+  // External paths should be used as-is, not nested under codefetch/prompts/
+  if (
+    config.defaultPromptFile.includes("/") ||
+    config.defaultPromptFile.includes("\\") ||
+    config.defaultPromptFile.startsWith(".")
+  ) {
+    return resolve(config.defaultPromptFile);
+  }
   return resolve(config.outputPath, "prompts", config.defaultPromptFile);
 }
 

--- a/packages/cli/test/unit/markdown.test.ts
+++ b/packages/cli/test/unit/markdown.test.ts
@@ -8,7 +8,8 @@ const UTILS_DIR = join(FIXTURE_DIR, "src/utils");
 
 describe("generateMarkdown with chunk-based token limit", () => {
   it("enforces maxTokens by chunk-based reading", async () => {
-    const MAX_TOKENS = 50;
+    // Note: XML tags (<source_code>, </source_code>) add ~4 tokens overhead
+    const MAX_TOKENS = 55;
     const files = [join(UTILS_DIR, "test1.ts"), join(UTILS_DIR, "test2.js")];
 
     const result = await generateMarkdown(files, {
@@ -72,6 +73,12 @@ describe("generateMarkdown with chunk-based token limit", () => {
       disableLineNumbers: false,
     });
 
+    // Check for XML tags
+    expect(markdown).toContain("<filetree>");
+    expect(markdown).toContain("</filetree>");
+    expect(markdown).toContain("<source_code>");
+    expect(markdown).toContain("</source_code>");
+    // Check content
     expect(markdown).toContain("Project Structure:");
     expect(markdown).toMatch(/└── /);
     expect(markdown).toContain("test1.ts");
@@ -81,8 +88,9 @@ describe("generateMarkdown with chunk-based token limit", () => {
   it("respects token limits with project tree", async () => {
     const files = [join(UTILS_DIR, "test1.ts")];
 
+    // Note: XML tags (<filetree>, <source_code>) add overhead
     const markdown = await generateMarkdown(files, {
-      maxTokens: 20,
+      maxTokens: 40,
       verbose: 0,
       projectTree: 2,
       tokenEncoder: "simple",
@@ -90,7 +98,7 @@ describe("generateMarkdown with chunk-based token limit", () => {
     });
 
     const tokens = await countTokens(markdown, "simple");
-    expect(tokens).toBeLessThanOrEqual(20);
+    expect(tokens).toBeLessThanOrEqual(40);
   });
 });
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.2.0
+
+### Added
+- **XML-structured output format** - Output now uses semantic XML tags for better AI parsing:
+  - `<task>...</task>` - Wraps the prompt/instructions
+  - `<filetree>...</filetree>` - Wraps the project tree structure
+  - `<source_code>...</source_code>` - Wraps all source code files
+- **Additive `includeDirs` and `includeFiles`** - These options now work together additively instead of being mutually exclusive
+- Added `hasCodebasePlaceholder` helper function to `template-parser.ts`
+
+### Fixed
+- Fixed `collectFiles` treating `includeDirs` and `includeFiles` as mutually exclusive - now they combine additively
+- Fixed `processPromptTemplate` to prepend prompts without `{{CURRENT_CODEBASE}}` placeholder to the codebase content instead of replacing it
+
 ## 2.0.4
 
 ### Added

--- a/packages/sdk/src/template-parser.ts
+++ b/packages/sdk/src/template-parser.ts
@@ -27,10 +27,17 @@ export async function processPromptTemplate(
     result = result.replace(new RegExp(`{{${key}}}`, "g"), value);
   }
 
-  // Always process CURRENT_CODEBASE first
+  // Replace CURRENT_CODEBASE placeholder with codebase content
   result = result.replace(/{{CURRENT_CODEBASE}}/g, codebase);
 
   return result;
+}
+
+/**
+ * Check if a template contains the CURRENT_CODEBASE placeholder
+ */
+export function hasCodebasePlaceholder(template: string): boolean {
+  return template.includes("{{CURRENT_CODEBASE}}");
 }
 
 export async function resolvePrompt(

--- a/packages/sdk/test/files.test.ts
+++ b/packages/sdk/test/files.test.ts
@@ -206,7 +206,9 @@ describe("File Collection", () => {
     test("should combine includeDirs and includeFiles additively", async () => {
       // Create directory structure simulating a real project
       await mkdir(join(tempDir, "crates", "core", "src"), { recursive: true });
-      await mkdir(join(tempDir, "crates", "engine", "src"), { recursive: true });
+      await mkdir(join(tempDir, "crates", "engine", "src"), {
+        recursive: true,
+      });
       await mkdir(join(tempDir, "crates", "utils", "src"), { recursive: true });
       await mkdir(join(tempDir, "src"), { recursive: true });
 

--- a/playground/sample-rust-project/.codefetchignore
+++ b/playground/sample-rust-project/.codefetchignore
@@ -1,0 +1,5 @@
+# Codefetch specific ignores
+*.log
+temp/
+cache/
+secret.rs

--- a/playground/sample-rust-project/.gitignore
+++ b/playground/sample-rust-project/.gitignore
@@ -1,0 +1,13 @@
+# Build artifacts
+target/
+dist/
+
+# Node modules
+node_modules/
+
+# IDE
+.idea/
+.vscode/
+
+# OS
+.DS_Store

--- a/playground/sample-rust-project/Cargo.toml
+++ b/playground/sample-rust-project/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+members = ["crates/*"]
+
+[package]
+name = "sample-rust-project"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/playground/sample-rust-project/crates/core/src/errors.rs
+++ b/playground/sample-rust-project/crates/core/src/errors.rs
@@ -1,0 +1,17 @@
+// Core error types
+use std::fmt;
+
+#[derive(Debug)]
+pub enum CoreError {
+    NotFound(String),
+    InvalidInput(String),
+}
+
+impl fmt::Display for CoreError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CoreError::NotFound(msg) => write!(f, "Not found: {}", msg),
+            CoreError::InvalidInput(msg) => write!(f, "Invalid input: {}", msg),
+        }
+    }
+}

--- a/playground/sample-rust-project/crates/core/src/lib.rs
+++ b/playground/sample-rust-project/crates/core/src/lib.rs
@@ -1,0 +1,7 @@
+// Core library - main entry point
+pub mod types;
+pub mod errors;
+
+pub fn init() {
+    println!("Core initialized");
+}

--- a/playground/sample-rust-project/crates/core/src/secret.rs
+++ b/playground/sample-rust-project/crates/core/src/secret.rs
@@ -1,0 +1,2 @@
+// This should be ignored by .codefetchignore
+const SECRET_KEY: &str = "super-secret-key-12345";

--- a/playground/sample-rust-project/crates/core/src/types.rs
+++ b/playground/sample-rust-project/crates/core/src/types.rs
@@ -1,0 +1,9 @@
+// Core types
+pub struct Config {
+    pub name: String,
+    pub debug: bool,
+}
+
+pub struct Context {
+    pub config: Config,
+}

--- a/playground/sample-rust-project/crates/engine/src/lib.rs
+++ b/playground/sample-rust-project/crates/engine/src/lib.rs
@@ -1,0 +1,10 @@
+// Engine library - processing logic
+use core::types::Context;
+
+pub fn process(ctx: &Context) {
+    println!("Processing with context: {:?}", ctx.config.name);
+}
+
+pub fn run() {
+    println!("Engine running");
+}

--- a/playground/sample-rust-project/crates/engine/src/processor.rs
+++ b/playground/sample-rust-project/crates/engine/src/processor.rs
@@ -1,0 +1,10 @@
+// Engine processor - should NOT be included when using includeFiles for lib.rs only
+pub struct Processor {
+    pub name: String,
+}
+
+impl Processor {
+    pub fn new(name: &str) -> Self {
+        Processor { name: name.to_string() }
+    }
+}

--- a/playground/sample-rust-project/crates/utils/src/lib.rs
+++ b/playground/sample-rust-project/crates/utils/src/lib.rs
@@ -1,0 +1,4 @@
+// Utils library - should NOT be included
+pub fn helper() -> String {
+    "helper".to_string()
+}

--- a/playground/sample-rust-project/docs/arch/architecture.md
+++ b/playground/sample-rust-project/docs/arch/architecture.md
@@ -1,0 +1,12 @@
+# Architecture Document
+
+## Overview
+This is the architecture document for the sample project.
+
+## Components
+- Core: Base types and errors
+- Engine: Processing logic
+- Utils: Helper functions
+
+## Instructions
+Please analyze this codebase and suggest improvements.

--- a/playground/sample-rust-project/docs/arch/decisions.md
+++ b/playground/sample-rust-project/docs/arch/decisions.md
@@ -1,0 +1,7 @@
+# Decision Log
+
+## Decision 1: Use Rust
+We chose Rust for memory safety and performance.
+
+## Decision 2: Modular Architecture
+Split into crates for better separation of concerns.

--- a/playground/sample-rust-project/src/main.rs
+++ b/playground/sample-rust-project/src/main.rs
@@ -1,0 +1,4 @@
+// Main application - should NOT be included
+fn main() {
+    println!("Hello from main!");
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1(magicast@0.3.5)
       codefetch-sdk:
-        specifier: workspace:*
-        version: link:../sdk
+        specifier: ^2.1.0
+        version: 2.1.2(magicast@0.3.5)
       consola:
         specifier: ^3.3.3
         version: 3.3.3
@@ -101,8 +101,8 @@ importers:
         specifier: ^1.13.2
         version: 1.13.2
       codefetch-sdk:
-        specifier: workspace:*
-        version: link:../sdk
+        specifier: ^2.1.0
+        version: 2.1.2(magicast@0.3.5)
 
   packages/sdk:
     dependencies:
@@ -1704,6 +1704,9 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  codefetch-sdk@2.1.2:
+    resolution: {integrity: sha512-h3y8BJhwkfV++8rdi1XVddTkzoE6aWInTuPNAS2up4ZnWzTKOiZl7uso+BvJ1ohf3pcYlUDD5I48F1uUjHysiw==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -5075,6 +5078,19 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  codefetch-sdk@2.1.2(magicast@0.3.5):
+    dependencies:
+      adm-zip: 0.5.16
+      c12: 2.0.1(magicast@0.3.5)
+      consola: 3.4.2
+      defu: 6.1.4
+      fast-glob: 3.3.3
+      ignore: 7.0.0
+      js-tiktoken: 1.0.16
+      pathe: 2.0.3
+    transitivePeerDependencies:
+      - magicast
 
   color-convert@2.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1(magicast@0.3.5)
       codefetch-sdk:
-        specifier: ^2.1.0
-        version: 2.1.2(magicast@0.3.5)
+        specifier: workspace:*
+        version: link:../sdk
       consola:
         specifier: ^3.3.3
         version: 3.3.3


### PR DESCRIPTION
## Summary

- **Fix `--include-dir` and `--include-files` to work additively** - Previously mutually exclusive, now they combine so you can include specific directories PLUS specific files
- **Support external prompt file paths** - Prompts like `-p docs/arch/prompt.md` now work correctly instead of requiring files in `codefetch/prompts/`
- **Add XML-structured output format** - Output now uses semantic XML tags (`<task>`, `<filetree>`, `<source_code>`) for better AI model parsing

## Changes

### Core Fixes
- `packages/sdk/src/files.ts` - Restructured pattern building to combine `includeDirs` and `includeFiles` additively
- `packages/cli/src/commands/default.ts` & `open.ts` - Fixed `getPromptFile` to handle external file paths
- `packages/sdk/src/template-parser.ts` - Added `hasCodebasePlaceholder` helper
- `packages/sdk/src/markdown.ts` - Added XML tags and prepend logic for prompts without placeholder

### Tests
- Added E2E tests for combined `--include-dir` + `--include-files`
- Added sample project in `playground/sample-rust-project/` for manual testing
- Updated token limit tests to account for XML tag overhead

### Documentation
- Updated README with XML output format section
- Updated README with combined include example
- Updated all changelogs for v2.2.0

## Test Plan

- [x] SDK tests pass (269 passed)
- [x] CLI tests pass (119 passed)
- [x] Manual testing with sample project verified:
  - [x] `--include-dir` alone works
  - [x] `--include-files` alone works
  - [x] Both combined work additively
  - [x] External prompt files work
  - [x] Inline prompts work
  - [x] XML tags present in output
  - [x] `.gitignore` respected
  - [x] `.codefetchignore` respected